### PR TITLE
bugfix on ID calc while using microsecond info

### DIFF
--- a/src/s1_burst_id/BurstDataFrame.py
+++ b/src/s1_burst_id/BurstDataFrame.py
@@ -120,7 +120,7 @@ class BurstDataFrame:
         for index, burst in enumerate(list(burstList)):
             sensingStart = burst.find('azimuthTime').text
             dt = read_time(sensingStart)-read_time(ascNodeTime)
-            time_info = int((dt.seconds + dt.microseconds*1e6)/burst_interval)
+            time_info = int((dt.seconds + dt.microseconds/1e6) / burst_interval)
             burstID = "t"+str(trackNumber) + "s" + self.swath + "b" + str(time_info)
             thisBurstCoords, xc, yc = self.burstCoords(geocords, lineperburst, index)
             # check if self.df has this dt for this track. If not append it


### PR DESCRIPTION
A simple fix as described in the title.